### PR TITLE
Add formatCurrency unit test

### DIFF
--- a/__tests__/formatCurrency.test.ts
+++ b/__tests__/formatCurrency.test.ts
@@ -1,0 +1,5 @@
+import { formatCurrency } from '@/lib/utils';
+
+test('formata número em BRL', () => {
+  expect(formatCurrency(1234.5)).toBe('R$\u00A01.234,50');
+});


### PR DESCRIPTION
## Summary
- add a unit test for `formatCurrency`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571736b80c8330a6c68ec6a1d84bdb